### PR TITLE
[*.py] Rename "Arguments:" to "Args:"

### DIFF
--- a/tensorflow_model_remediation/min_diff/keras/models/min_diff_model.py
+++ b/tensorflow_model_remediation/min_diff/keras/models/min_diff_model.py
@@ -34,7 +34,7 @@ class MinDiffModel(tf.keras.Model):
 
   Inherits from: `tf.keras.Model`
 
-  Arguments:
+  Args:
     original_model: Instance of `tf.keras.Model` that will be trained with the
       additional `min_diff_loss`.
     loss: String (name of loss) or `min_diff.losses.MinDiffLoss` instance that
@@ -234,7 +234,7 @@ class MinDiffModel(tf.keras.Model):
     # pyformat: disable
     """Extracts original_inputs from `inputs`.
 
-    Arguments:
+    Args:
       inputs: `inputs` as described in `MinDiffModel.call`.
 
     Identifies whether `min_diff_data` is included in `inputs`. If it is, then
@@ -274,7 +274,7 @@ class MinDiffModel(tf.keras.Model):
     # pyformat: disable
     """Extracts `min_diff_data` from `inputs` if present or returns `None`.
 
-    Arguments:
+    Args:
       inputs: `inputs` as described in `MinDiffModel.call`.
 
 
@@ -314,7 +314,7 @@ class MinDiffModel(tf.keras.Model):
     # pyformat: disable
     """Computes and returns the `min_diff_loss` corresponding to `min_diff_data`.
 
-    Arguments:
+    Args:
       min_diff_data: Tuple of length 2 or 3 as described below.
       training: Boolean indicating whether to run in training or inference mode.
         See `tf.keras.Model.call` for details.

--- a/tensorflow_model_remediation/min_diff/keras/utils/input_utils.py
+++ b/tensorflow_model_remediation/min_diff/keras/utils/input_utils.py
@@ -49,7 +49,7 @@ def pack_min_diff_data(
   # pyformat: disable
   """Packs `min_diff_data` with the `x` component of the original dataset.
 
-  Arguments:
+  Args:
     original_dataset: `tf.data.Dataset` that was used before applying min
       diff. The output should conform to the format used in
       `tf.keras.Model.fit`.
@@ -185,7 +185,7 @@ def pack_min_diff_data(
 def unpack_original_inputs(inputs):
   """Unpacks `original_inputs` from a `utils.MinDiffPackedInputs` instance.
 
-  Arguments:
+  Args:
     inputs: Data to be unpacked, if possible.
 
   Returns:
@@ -200,7 +200,7 @@ def unpack_original_inputs(inputs):
 def unpack_min_diff_data(inputs):
   """Unpacks `min_diff_data` from a `utils.MinDiffPackedInputs` instance.
 
-  Arguments:
+  Args:
     inputs: Data to be unpacked, if possible.
 
   Returns:

--- a/tensorflow_model_remediation/min_diff/losses/absolute_correlation_loss.py
+++ b/tensorflow_model_remediation/min_diff/losses/absolute_correlation_loss.py
@@ -29,7 +29,7 @@ class AbsoluteCorrelationLoss(base_loss.MinDiffLoss):
   # pyformat: disable
   """Absolute correlation between predictions on two groups of examples.
 
-  Arguments:
+  Args:
     name: Name used for logging or tracking. Defaults to
       `'absolute_correlation_loss'`.
 

--- a/tensorflow_model_remediation/min_diff/losses/base_loss.py
+++ b/tensorflow_model_remediation/min_diff/losses/base_loss.py
@@ -33,7 +33,7 @@ class MinDiffLoss(tf.keras.losses.Loss, abc.ABC):
 
   Inherits from: `tf.keras.losses.Loss`
 
-  Arguments:
+  Args:
     membership_transform: Transform function used on `membership`. If `None` is
       passed in then `membership` is left as is. The function must return a
       `tf.Tensor`.
@@ -158,7 +158,7 @@ class MinDiffLoss(tf.keras.losses.Loss, abc.ABC):
     # pyformat: disable
     """Preprocesses inputs by applying transforms and normalizing weights.
 
-    Arguments:
+    Args:
       membership: `membership` column as described in
         `MinDiffLoss.call`.
       predictions: `predictions` tensor as described in `MinDiffLoss.call`.
@@ -218,7 +218,7 @@ class MinDiffLoss(tf.keras.losses.Loss, abc.ABC):
     # pyformat: disable
     """Applies `losses.MinDiffKernel` attributes to corresponding inputs.
 
-    Arguments:
+    Args:
       membership: `membership` column as described in `MinDiffLoss.call`.
       predictions: `predictions` tensor as described in `MinDiffLoss.call`.
 
@@ -275,7 +275,7 @@ class MinDiffLoss(tf.keras.losses.Loss, abc.ABC):
     # pyformat: disable
     """Invokes the `MinDiffLoss` instance.
 
-    Arguments:
+    Args:
       membership: Numerical `Tensor` indicating whether examples are
         part of the sensitive_group. This is often denoted with `1.0` or `0.0`
         for `True` or `False` respectively but the details are determined by the

--- a/tensorflow_model_remediation/min_diff/losses/kernels/base_kernel.py
+++ b/tensorflow_model_remediation/min_diff/losses/kernels/base_kernel.py
@@ -29,7 +29,7 @@ class MinDiffKernel(abc.ABC):
   # pyformat: disable
   """MinDiffKernel abstract base class.
 
-  Arguments:
+  Args:
     tile_input: Boolean indicating whether to tile inputs before computing the
       kernel (see below for details).
 
@@ -64,7 +64,7 @@ class MinDiffKernel(abc.ABC):
     # pyformat: disable
     """Invokes the kernel instance.
 
-    Arguments:
+    Args:
       x: `tf.Tensor` of shape `[N, D]` (if tiling input) or `[N, M, D]` (if not
         tiling input).
       y: Optional `tf.Tensor` of shape `[M, D]` (if tiling input) or `[N, M, D]`
@@ -96,7 +96,7 @@ class MinDiffKernel(abc.ABC):
     # pyformat: disable
     """Invokes the `MinDiffKernel` instance.
 
-    Arguments:
+    Args:
       x: `tf.Tensor` of shape `[N, M, D]`.
       y: `tf.Tensor` of shape `[N, M, D]`.
 

--- a/tensorflow_model_remediation/min_diff/losses/kernels/gaussian_kernel.py
+++ b/tensorflow_model_remediation/min_diff/losses/kernels/gaussian_kernel.py
@@ -31,7 +31,7 @@ class GaussianKernel(base_kernel.MinDiffKernel):
   distribution as a sum of gaussian distributions. This is particularly useful
   when we are trying to determine a distribution from a set of points.
 
-  Arguments:
+  Args:
     kernel_length: Length (sometimes also called 'width') of the kernel.
       Defaults to `0.1`. This parameter essentially describes how far apart
       points can be and still affect each other.

--- a/tensorflow_model_remediation/min_diff/losses/kernels/laplacian_kernel.py
+++ b/tensorflow_model_remediation/min_diff/losses/kernels/laplacian_kernel.py
@@ -27,7 +27,7 @@ class LaplacianKernel(base_kernel.MinDiffKernel):
   # pyformat: disable
   """Laplacian kernel class.
 
-  Arguments:
+  Args:
     kernel_length: Length (sometimes also called 'width') of the kernel.
       Defaults to `0.1`. This parameter essentially describes how far apart
       points can be and still affect each other.

--- a/tensorflow_model_remediation/min_diff/losses/mmd_loss.py
+++ b/tensorflow_model_remediation/min_diff/losses/mmd_loss.py
@@ -29,7 +29,7 @@ class MMDLoss(base_loss.MinDiffLoss):
   # pyformat: disable
   """Maximum Mean Discrepency between predictions on two groups of examples.
 
-  Arguments:
+  Args:
     kernel: String (name of kernel) or `losses.MinDiffKernel` instance to be
       applied on the predictions. Defaults to `'gaussian'` and it is recommended
       that this be either


### PR DESCRIPTION
I've written custom parsers and emitters for everything from docstrings to classes and functions. However, I recently came across an issue with the TensorFlow codebase: inconsistent use of `Args:` and `Arguments:` in its docstrings. It is easy enough to extend my parsers to support both variants, however it looks like `Arguments:` is wrong anyway, as per:

  - https://google.github.io/styleguide/pyguide.html#doc-function-args @ [`ddccc0f`](https://github.com/google/styleguide/blob/ddccc0f/pyguide.md)

  - https://chromium.googlesource.com/chromiumos/docs/+/master/styleguide/python.md#describing-arguments-in-docstrings @ [`9fc0fc0`](https://chromium.googlesource.com/chromiumos/docs/+/9fc0fc0/styleguide/python.md)

  - https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html @ [`c0ae8e3`](https://github.com/sphinx-contrib/napoleon/blob/c0ae8e3/docs/source/example_google.rst)

Therefore, only `Args:` is valid. This PR replaces them throughout the codebase.

PS: For related PRs, see tensorflow/tensorflow/pull/45420